### PR TITLE
New CLI flag for comparison customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@ Locally, you can clone this repository, build it via the Makefile, and run it by
 make build
 ./bin/jsonDiff-darwin json1.json json2.json
 ```
-
 Make sure to use the appropriate binary for your OS. The above example is assuming you are on a Mac.
+
+## Additional CLI flags
+You can also use the `--byteskip` to skip the comparison if the second file has fewer bytes than the first.
+```bash
+./bin/jsonDiff-darwin json1.json json2.json --byteskip
+```
+
 
 # Viewing test coverage
 ```bash

--- a/compare.go
+++ b/compare.go
@@ -7,8 +7,9 @@ import (
 )
 
 type JSONDiff struct {
-	File1 File
-	File2 File
+	File1    File
+	File2    File
+	ByteSkip bool
 }
 
 func (j JSONDiff) FindDifferences() string {
@@ -22,6 +23,10 @@ func (j JSONDiff) FindDifferences() string {
 
 	if bytes.Equal(j.File1.Bytes, j.File2.Bytes) {
 		return "No differences found."
+	}
+
+	if j.ByteSkip && len(j.File2.Bytes) < len(j.File1.Bytes) {
+		return "Second file smaller than first and byteskip enabled"
 	}
 
 	if diff := deep.Equal(j.File1.Map, j.File2.Map); diff != nil {

--- a/compare_test.go
+++ b/compare_test.go
@@ -391,7 +391,7 @@ func TestJSONDiff_FindDifferencesWithSnykShape_Vulnerabilities(t *testing.T) {
 	}
 }
 
-func TestJSONDiff_FindDifference_NoBytes(t *testing.T) {
+func TestJSONDiff_FindDifferences_NoBytes(t *testing.T) {
 	j := JSONDiff{
 		File1: File{
 			Bytes: nil,
@@ -408,7 +408,7 @@ func TestJSONDiff_FindDifference_NoBytes(t *testing.T) {
 	}
 }
 
-func TestJSONDiff_FindDifference_NoMap(t *testing.T) {
+func TestJSONDiff_FindDifferences_NoMap(t *testing.T) {
 	j := JSONDiff{
 		File1: File{
 			Bytes: []byte(`{"key1": "value1"}`),
@@ -422,5 +422,24 @@ func TestJSONDiff_FindDifference_NoMap(t *testing.T) {
 
 	if got := j.FindDifferences(); got != "No map defined for File1 and/or File2." {
 		t.Errorf("JSONDiff.FindDifferences() = %v, want %v", got, "No map defined for File1 and/or File2.")
+	}
+}
+
+func TestJSONDiff_FindDIfferences_ByteSkip(t *testing.T) {
+	j := JSONDiff{
+		File1: File{
+			Bytes: []byte(`{"key1": "value1"}, {"key2": "value2"}`),
+			Map:   map[string]interface{}{"key1": "value1", "key2": "value2"},
+		},
+		File2: File{
+			Bytes: []byte(`{"key1": "value1"}`),
+			Map:   map[string]interface{}{"key1": "value1"},
+		},
+		ByteSkip: true,
+	}
+
+	expected := "Second file smaller than first and byteskip enabled"
+	if got := j.FindDifferences(); got != expected {
+		t.Errorf("JSONDiff.FindDifferences() = %v, want %v", got, expected)
 	}
 }

--- a/runner.go
+++ b/runner.go
@@ -14,12 +14,11 @@ type Runner struct {
 func (r Runner) Run(reader FileReader) (string, error) {
 	if len(r.Arguments) < 2 {
 		return "", errors.New("please provide two JSON files to compare")
-
 	}
 
-	args := r.Arguments[0:2]
+	fileArgs := r.Arguments[0:2]
 	var files []File
-	for _, arg := range args {
+	for _, arg := range fileArgs {
 		file := File{
 			Reader: reader,
 		}
@@ -33,6 +32,10 @@ func (r Runner) Run(reader FileReader) (string, error) {
 	comparator := JSONDiff{
 		File1: files[0],
 		File2: files[1],
+	}
+
+	if (len(r.Arguments) == 3) && (r.Arguments[2] == "--byteskip") {
+		comparator.ByteSkip = true
 	}
 
 	return comparator.FindDifferences(), nil

--- a/runner_test.go
+++ b/runner_test.go
@@ -66,3 +66,19 @@ func TestRunner_Run_InvalidFiles(t *testing.T) {
 		t.Errorf("Expected error, but got did not get one")
 	}
 }
+
+func TestRunner_Run_ByteSkip(t *testing.T) {
+	mockFileReader := MockFileReader{
+		Content: []byte(`{"key1": "value1"}`),
+		Err:     nil,
+	}
+
+	runner := Runner{
+		Arguments: []string{"file1.json", "file2.json", "--byteskip"},
+	}
+
+	_, err := runner.Run(mockFileReader)
+	if err != nil {
+		t.Fatalf("Expected no error, but got %v", err)
+	}
+}


### PR DESCRIPTION
Adds a new flag `--byteskip` that allows skipping comparison if the second file has fewer bytes than the first